### PR TITLE
Remove pil dependency

### DIFF
--- a/generators/pdf417gen/__init__.py
+++ b/generators/pdf417gen/__init__.py
@@ -1,4 +1,4 @@
 from . encoding import encode
-from . rendering import render_image, render_svg
+# from . rendering import render_image, render_svg
 
-__all__ = [encode, render_image, render_svg]
+__all__ = [encode]  #, render_image, render_svg]

--- a/generators/pdf417gen/rendering.py
+++ b/generators/pdf417gen/rendering.py
@@ -1,4 +1,4 @@
-from PIL import Image, ImageColor, ImageOps
+# from PIL import Image, ImageColor, ImageOps
 from xml.etree.ElementTree import ElementTree, Element, SubElement
 
 
@@ -27,7 +27,7 @@ def modules(codes):
                 yield col_id, row_id, digit == "1"
                 col_id += 1
 
-
+'''
 def parse_color(color):
     return ImageColor.getrgb(color)
 
@@ -99,3 +99,4 @@ def render_svg(codes, scale=3, ratio=3, color="#000", description=None):
             })
 
     return ElementTree(element=root)
+'''


### PR DESCRIPTION
Crudely hacks the PIL requirement out of PDF417Gen. there is probably a better way to do this, but this works. None of the stuff requiring PIL is used, so it's probably fine.